### PR TITLE
feat: Add props parameter to FsxLifecycleStatusMonitor constructor

### DIFF
--- a/API.md
+++ b/API.md
@@ -35,13 +35,14 @@ yarn integ-runner --directory ./integ-tests  --update-on-failed --parallel-regio
 ```typescript
 import { FsxLifecycleStatusMonitor } from 'aws_fsx_lifecycle_status_monitor'
 
-new FsxLifecycleStatusMonitor(scope: Construct, id: string)
+new FsxLifecycleStatusMonitor(scope: Construct, id: string, props: FsxLifecycleStatusMonitorProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitor.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - parent construct. |
 | <code><a href="#aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitor.Initializer.parameter.id">id</a></code> | <code>string</code> | - unique id. |
+| <code><a href="#aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitor.Initializer.parameter.props">props</a></code> | <code><a href="#aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitorProps">FsxLifecycleStatusMonitorProps</a></code> | *No description.* |
 
 ---
 
@@ -58,6 +59,12 @@ parent construct.
 - *Type:* string
 
 unique id.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitor.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitorProps">FsxLifecycleStatusMonitorProps</a>
 
 ---
 
@@ -190,6 +197,63 @@ public readonly topic: Topic;
 
 ---
 
+#### Constants <a name="Constants" id="Constants"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitor.property.DEFAULT_SCHEDULE">DEFAULT_SCHEDULE</a></code> | <code>aws-cdk-lib.aws_events.Schedule</code> | *No description.* |
+
+---
+
+##### `DEFAULT_SCHEDULE`<sup>Required</sup> <a name="DEFAULT_SCHEDULE" id="aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitor.property.DEFAULT_SCHEDULE"></a>
+
+```typescript
+public readonly DEFAULT_SCHEDULE: Schedule;
+```
+
+- *Type:* aws-cdk-lib.aws_events.Schedule
+
+---
+
+## Structs <a name="Structs" id="Structs"></a>
+
+### FsxLifecycleStatusMonitorProps <a name="FsxLifecycleStatusMonitorProps" id="aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitorProps"></a>
+
+Properties for the FSx Lifecycle Status Monitor.
+
+#### Initializer <a name="Initializer" id="aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitorProps.Initializer"></a>
+
+```typescript
+import { FsxLifecycleStatusMonitorProps } from 'aws_fsx_lifecycle_status_monitor'
+
+const fsxLifecycleStatusMonitorProps: FsxLifecycleStatusMonitorProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitorProps.property.schedule">schedule</a></code> | <code>aws-cdk-lib.aws_events.Schedule</code> | The schedule for the FSx Lifecycle Status Monitor. |
+
+---
+
+##### `schedule`<sup>Optional</sup> <a name="schedule" id="aws_fsx_lifecycle_status_monitor.FsxLifecycleStatusMonitorProps.property.schedule"></a>
+
+```typescript
+public readonly schedule: Schedule;
+```
+
+- *Type:* aws-cdk-lib.aws_events.Schedule
+
+The schedule for the FSx Lifecycle Status Monitor.
+
+---
+
+*Example*
+
+```typescript
+"events.Schedule.cron({ minute: '0/10', hour: '*', day: '*', month: '*', year: '*' })"
+```
 
 
 

--- a/integ-tests/integ.monitor.test.ts
+++ b/integ-tests/integ.monitor.test.ts
@@ -8,7 +8,7 @@ class StackUnderTest extends cdk.Stack {
 
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-    this.monitor = new FsxLifecycleStatusMonitor(this, "monitor");
+    this.monitor = new FsxLifecycleStatusMonitor(this, "monitor",{});
   }
 }
 
@@ -44,7 +44,7 @@ integ.assertions
   })
   .expect(
     ExpectedResult.objectLike({
-      Description: "Trigger the FSx health check every 10 minutes",
+      Description: "Trigger the FSx health check based on the underlying cron expression",
         ScheduleExpression: "cron(0/10 * * * ? *)",
       Name: 'fsx-health-trigger',
       State: 'ENABLED',

--- a/integ-tests/integ.monitor.test.ts.snapshot/MyTestCaseDefaultTestDeployAssertD814CC8D.assets.json
+++ b/integ-tests/integ.monitor.test.ts.snapshot/MyTestCaseDefaultTestDeployAssertD814CC8D.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "085fc9eae97f1d5baee9a61bae7f54a121cf490a646bcfeaf2203d472cca531c": {
+    "6ea59226de9cef0d80a05ee2014e762018aa0ca4aacc91cf549b8d76d9536696": {
       "source": {
         "path": "MyTestCaseDefaultTestDeployAssertD814CC8D.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "085fc9eae97f1d5baee9a61bae7f54a121cf490a646bcfeaf2203d472cca531c.json",
+          "objectKey": "6ea59226de9cef0d80a05ee2014e762018aa0ca4aacc91cf549b8d76d9536696.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/integ-tests/integ.monitor.test.ts.snapshot/MyTestCaseDefaultTestDeployAssertD814CC8D.template.json
+++ b/integ-tests/integ.monitor.test.ts.snapshot/MyTestCaseDefaultTestDeployAssertD814CC8D.template.json
@@ -18,7 +18,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1689612365941"
+    "salt": "1689682417284"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -115,14 +115,14 @@
     },
     "service": "EventBridge",
     "api": "describeRule",
-    "expected": "{\"$ObjectLike\":{\"Description\":\"Trigger the FSx health check every 10 minutes\",\"ScheduleExpression\":\"cron(0/10 * * * ? *)\",\"Name\":\"fsx-health-trigger\",\"State\":\"ENABLED\"}}",
+    "expected": "{\"$ObjectLike\":{\"Description\":\"Trigger the FSx health check based on the underlying cron expression\",\"ScheduleExpression\":\"cron(0/10 * * * ? *)\",\"Name\":\"fsx-health-trigger\",\"State\":\"ENABLED\"}}",
     "parameters": {
      "Name": {
       "Fn::ImportValue": "monitor-stack:ExportsOutputRefmonitorrule99C4CAB40309C047"
      }
     },
     "flattenResponse": "false",
-    "salt": "1689612365941"
+    "salt": "1689682417285"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/integ-tests/integ.monitor.test.ts.snapshot/manifest.json
+++ b/integ-tests/integ.monitor.test.ts.snapshot/manifest.json
@@ -17,7 +17,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4dc5fa7ffb1f728265d79912f03ddcb00f353158d3953dd660dea41a17c18e36.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/48391a8c34f5d4ff92f45f7868c2d12d7973e5cc6d155621f11dd10e8d197681.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -136,7 +136,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/085fc9eae97f1d5baee9a61bae7f54a121cf490a646bcfeaf2203d472cca531c.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/6ea59226de9cef0d80a05ee2014e762018aa0ca4aacc91cf549b8d76d9536696.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/integ-tests/integ.monitor.test.ts.snapshot/monitor-stack.assets.json
+++ b/integ-tests/integ.monitor.test.ts.snapshot/monitor-stack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "4dc5fa7ffb1f728265d79912f03ddcb00f353158d3953dd660dea41a17c18e36": {
+    "48391a8c34f5d4ff92f45f7868c2d12d7973e5cc6d155621f11dd10e8d197681": {
       "source": {
         "path": "monitor-stack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4dc5fa7ffb1f728265d79912f03ddcb00f353158d3953dd660dea41a17c18e36.json",
+          "objectKey": "48391a8c34f5d4ff92f45f7868c2d12d7973e5cc6d155621f11dd10e8d197681.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/integ-tests/integ.monitor.test.ts.snapshot/monitor-stack.template.json
+++ b/integ-tests/integ.monitor.test.ts.snapshot/monitor-stack.template.json
@@ -165,7 +165,7 @@
   "monitorrule99C4CAB4": {
    "Type": "AWS::Events::Rule",
    "Properties": {
-    "Description": "Trigger the FSx health check every 10 minutes",
+    "Description": "Trigger the FSx health check based on the underlying cron expression",
     "Name": "fsx-health-trigger",
     "ScheduleExpression": "cron(0/10 * * * ? *)",
     "State": "ENABLED",

--- a/integ-tests/integ.monitor.test.ts.snapshot/tree.json
+++ b/integ-tests/integ.monitor.test.ts.snapshot/tree.json
@@ -302,7 +302,7 @@
                     "attributes": {
                       "aws:cdk:cloudformation:type": "AWS::Events::Rule",
                       "aws:cdk:cloudformation:props": {
-                        "description": "Trigger the FSx health check every 10 minutes",
+                        "description": "Trigger the FSx health check based on the underlying cron expression",
                         "name": "fsx-health-trigger",
                         "scheduleExpression": "cron(0/10 * * * ? *)",
                         "state": "ENABLED",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './monitor';
+export * from './monitorProps';

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -9,12 +9,23 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sns from 'aws-cdk-lib/aws-sns';
 
 import { Construct } from 'constructs';
+import { FsxLifecycleStatusMonitorProps } from './monitorProps';
 
 export class FsxLifecycleStatusMonitor extends Construct {
+
+  public static readonly DEFAULT_SCHEDULE = events.Schedule.cron({
+    minute: '0/10',
+    hour: '*',
+    day: '*',
+    month: '*',
+    year: '*',
+  });
+
   fn: lambda.Function;
   topic: sns.Topic;
   policy: iam.Policy;
   rule: events.Rule;
+
 
   /**
    * Creates an instance of FsxLifecycleStatusMonitor.
@@ -22,7 +33,7 @@ export class FsxLifecycleStatusMonitor extends Construct {
    * @param {string} id - unique id
    * @memberof FsxLifecycleStatusMonitor - class instance
    */
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props: FsxLifecycleStatusMonitorProps) {
     super(scope, id);
     this.topic = this.createSNSTopic();
     this.policy = this.createIamPolicy();
@@ -31,14 +42,8 @@ export class FsxLifecycleStatusMonitor extends Construct {
 
     this.rule = new events.Rule(this, 'rule', {
       ruleName: 'fsx-health-trigger',
-      description: 'Trigger the FSx health check every 10 minutes',
-      schedule: events.Schedule.cron({
-        minute: '0/10',
-        hour: '*',
-        day: '*',
-        month: '*',
-        year: '*',
-      }),
+      description: 'Trigger the FSx health check based on the underlying cron expression',
+      schedule: props.schedule ? props.schedule : FsxLifecycleStatusMonitor.DEFAULT_SCHEDULE,
       targets: [new targets.LambdaFunction(this.fn)],
     });
   }

--- a/src/monitorProps.ts
+++ b/src/monitorProps.ts
@@ -1,0 +1,21 @@
+import * as events from 'aws-cdk-lib/aws-events';
+
+
+/**
+ * Properties for the FSx Lifecycle Status Monitor.
+ *
+ * @export
+ * @interface FsxLifecycleStatusMonitorProps
+ */
+export interface FsxLifecycleStatusMonitorProps {
+  /**
+   * The schedule for the FSx Lifecycle Status Monitor.
+   *
+   * @type {events.Schedule}
+   *
+   * @memberof FsxLifecycleStatusMonitorProps
+   *
+   * @example "events.Schedule.cron({ minute: '0/10', hour: '*', day: '*', month: '*', year: '*' })"
+   */
+  readonly schedule?: events.Schedule;
+}

--- a/test/monitor.test.ts
+++ b/test/monitor.test.ts
@@ -1,22 +1,46 @@
 
 import * as cdk from 'aws-cdk-lib';
+import { Schedule } from 'aws-cdk-lib/aws-events';
 import { FsxLifecycleStatusMonitor } from '../src';
 
-describe('SNS Topic Configuration', () => {
+describe('SNS topic configuration', () => {
   let stack: cdk.Stack;
 
   beforeEach(() => {
     const app = new cdk.App();
 
     stack = new cdk.Stack(app, 'stack', {});
-    new FsxLifecycleStatusMonitor(stack, 'monitor' );
+    new FsxLifecycleStatusMonitor(stack, 'monitor', {} );
   });
 
-  test('Fifo is disabled', () => {
+  test('SNS topic name is set', () => {
     cdk.assertions.Template.fromStack(stack).hasResourceProperties(
       'AWS::SNS::Topic',
       {
         DisplayName: 'fsx-lifecycle-monitor',
+      },
+    );
+  });
+});
+
+describe('Event rule configuration', () => {
+  let stack: cdk.Stack;
+
+  beforeEach(() => {
+    const app = new cdk.App();
+
+    stack = new cdk.Stack(app, 'stack', {});
+    new FsxLifecycleStatusMonitor(stack, 'monitor', {
+      schedule: Schedule.cron({ minute: '0/30', hour: '*', day: '*', month: '*', year: '*' }),
+    } );
+  });
+
+  test('Custom event bridge rule support', () => {
+    cdk.assertions.Template.fromStack(stack).hasResourceProperties(
+      'AWS::Events::Rule',
+      {
+        Name: 'fsx-health-trigger',
+        ScheduleExpression: 'cron(0/30 * * * ? *)',
       },
     );
   });


### PR DESCRIPTION
This commit adds a new optional `props` parameter to the `FsxLifecycleStatusMonitor` constructor in order to provide additional properties for the FSx Lifecycle Status Monitor. The `props` parameter is of type `FsxLifecycleStatusMonitorProps`. This change allows for more flexibility and customization when creating an instance of the monitor.

The commit also includes updates to the API documentation, specifically adding a new struct called `FsxLifecycleStatusMonitorProps`, which contains properties for the FSx Lifecycle Status Monitor. Additionally, a new constant called `DEFAULT_SCHEDULE` has been added to the monitor class.

In the integration tests, this commit modifies the instantiation of `FsxLifecycleStatusMonitor` by passing an empty object as the value for the new `props` parameter. It also updates some test assertions and snapshot files accordingly.

Fixes #4